### PR TITLE
Fix editable install package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,5 @@ dependencies = [
   "pillow>=10.4",
   "pip-system-certs>=5.3",
 ]
+[tool.setuptools.packages.find]
+include = ["seedvr_studio*"]


### PR DESCRIPTION
## Problem\nThe Windows installer failed during pip install --editable . because setuptools discovered multiple top-level directories in the flat repository layout and refused to guess which packages to include.\n\n## Fix\nConfigure setuptools package discovery to include only seedvr_studio*.\n\n## Verification\n- Ran .venv\\Scripts\\python.exe -m pip install --no-deps --editable .\n- Editable wheel built and installed successfully.\n\nThis is ready for the affected user to retest the installer.