### PR TITLE
Prevent TensorRT ONNX export installer hangs

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -56,3 +56,16 @@ Common failures:
 - **FFmpeg still missing after winget:** restart Windows so the system PATH refreshes, then rerun.
 
 The installer does not require a separate full CUDA Toolkit. The Python CUDA and TensorRT packages provide the runtime used by the Studio.
+
+
+### If TensorRT export appears hung
+
+The first TensorRT profile performs a fixed-shape ONNX export and can take several minutes. The installer prints an export start message and elapsed time; leave the window open while it runs. Engine preparation is resumable, so completed `.rtxplan` files are skipped on the next run.
+
+If you need to finish setup without TensorRT, run:
+
+```powershell
+.\scripts\install.ps1 -SkipTensorRT
+```
+
+This leaves SeedVR2 Legacy available. Run the installer again later to build missing GPU-specific engines.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $env:PYTHONUTF8 = '1'
 $env:PYTHONIOENCODING = 'utf-8'
+$env:PYTHONUNBUFFERED = '1'
 $StudioRoot = Split-Path -Parent $PSScriptRoot
 $Outputs = Join-Path $StudioRoot 'outputs'
 $Log = Join-Path $Outputs 'install.log'

--- a/scripts/prepare_tensorrt.py
+++ b/scripts/prepare_tensorrt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,7 +21,7 @@ PROFILES = (
 
 def run(command: list[str]) -> None:
     print("\n> " + subprocess.list2cmdline(command), flush=True)
-    subprocess.run(command, cwd=ROOT, check=True)
+    subprocess.run([command[0], "-u", *command[1:]], cwd=ROOT, check=True)
 
 
 def main() -> int:
@@ -31,12 +32,14 @@ def main() -> int:
         if engine.exists() and engine.stat().st_size > 1_000_000:
             print(f"Skipping {label}; engine already exists: {engine.name}")
             continue
-        print(f"\nPreparing TensorRT {label} profile...")
+        print(f"\nPreparing TensorRT {label} profile (keep this window open)...", flush=True)
+        started = time.perf_counter()
         if not onnx.exists():
             run([str(PYTHON), str(ROOT / "tools" / exporter), *arguments, "--output", str(onnx)])
         run([str(PYTHON), str(ROOT / "tools" / "build_tensorrt_engine.py"), str(onnx), "--output", str(engine), "--workspace-gb", "8"])
         if not engine.exists():
             raise RuntimeError(f"TensorRT did not create {engine}")
+        print(f"Completed {label} in {time.perf_counter() - started:.1f}s", flush=True)
     print("\nAll TensorRT VAE engines are ready.")
     return 0
 

--- a/tools/export_vae_decoder.py
+++ b/tools/export_vae_decoder.py
@@ -26,6 +26,7 @@ from src.utils.debug import Debug  # noqa: E402
 from src.utils.model_registry import DEFAULT_DIT, DEFAULT_VAE  # noqa: E402
 from src.models.video_vae_v3.modules.types import MemoryState  # noqa: E402
 from src.models.video_vae_v3.modules.causal_inflation_lib import InflatedCausalConv3d  # noqa: E402
+from onnx_export_utils import export_portable_onnx  # noqa: E402
 
 
 class Decoder(torch.nn.Module):
@@ -111,21 +112,7 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with torch.inference_mode():
         reference = decoder(latent)
-        # ONNX export must trace the portable convolution operators rather
-        # than CUDA-only aten::cudnn_convolution. Keep the CUDA result above
-        # as the reference, then export an identical CPU copy.
-        decoder_cpu = Decoder(vae.decoder.cpu()).eval()
-        latent_cpu = latent.cpu()
-        torch.onnx.export(
-            decoder_cpu,
-            (latent_cpu,),
-            str(args.output),
-            input_names=["latent"],
-            output_names=["sample"],
-            opset_version=20,
-            dynamo=not args.legacy_export,
-            optimize=False,
-        )
+        export_portable_onnx(decoder, (latent,), args.output, legacy=args.legacy_export)
     print(f"Exported: {args.output}")
     print(f"Latent shape: {tuple(latent.shape)}")
     print(f"Output shape: {tuple(reference.shape)}")

--- a/tools/export_vae_encoder.py
+++ b/tools/export_vae_encoder.py
@@ -21,6 +21,7 @@ from src.models.video_vae_v3.modules.types import MemoryState  # noqa: E402
 from src.models.video_vae_v3.modules.causal_inflation_lib import InflatedCausalConv3d  # noqa: E402
 from src.utils.debug import Debug  # noqa: E402
 from src.utils.model_registry import DEFAULT_DIT, DEFAULT_VAE  # noqa: E402
+from onnx_export_utils import export_portable_onnx  # noqa: E402
 
 
 class Encoder(torch.nn.Module):
@@ -80,10 +81,7 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with torch.inference_mode():
         reference = encoder(video)
-        encoder_cpu = Encoder(vae.cpu()).eval()
-        torch.onnx.export(encoder_cpu, (video.cpu(),), str(args.output),
-                          input_names=["video"], output_names=["latent_raw"],
-                          opset_version=20, dynamo=not args.legacy_export, optimize=False)
+        export_portable_onnx(encoder, (video,), args.output, legacy=args.legacy_export)
     print(f"Exported: {args.output}")
     print(f"Video shape: {tuple(video.shape)}")
     print(f"Raw latent shape: {tuple(reference.shape)}")

--- a/tools/onnx_export_utils.py
+++ b/tools/onnx_export_utils.py
@@ -1,0 +1,55 @@
+"""Portable, observable ONNX export helpers for TensorRT engine preparation."""
+
+from __future__ import annotations
+
+import time
+from contextlib import nullcontext
+from pathlib import Path
+
+import torch
+
+
+def _math_attention_context():
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+        return sdpa_kernel(SDPBackend.MATH)
+    except (ImportError, AttributeError):
+        return nullcontext()
+
+
+def _portable_export(module: torch.nn.Module, args: tuple[torch.Tensor, ...], output: Path, *, legacy: bool) -> None:
+    is_encoder = args[0].ndim == 5 and args[0].shape[1] == 3
+    with torch.inference_mode(), torch.backends.cudnn.flags(enabled=False), _math_attention_context():
+        torch.onnx.export(
+            module,
+            args,
+            str(output),
+            input_names=["video"] if is_encoder else ["latent"],
+            output_names=["latent_raw"] if is_encoder else ["sample"],
+            opset_version=20,
+            dynamo=not legacy,
+            optimize=False,
+            do_constant_folding=False,
+        )
+
+
+def export_portable_onnx(
+    module: torch.nn.Module,
+    args: tuple[torch.Tensor, ...],
+    output: Path,
+    *,
+    legacy: bool,
+) -> None:
+    """Export on CUDA with portable operators, falling back to CPU only on OOM."""
+    print(f"Exporting ONNX (legacy tracer, portable convs) -> {output}", flush=True)
+    started = time.perf_counter()
+    try:
+        _portable_export(module, args, output, legacy=legacy)
+    except RuntimeError as exc:
+        if "out of memory" not in str(exc).lower():
+            raise
+        print("CUDA ONNX export ran out of memory; falling back to CPU export. This may take a while.", flush=True)
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        _portable_export(module.cpu(), tuple(value.cpu() for value in args), output, legacy=legacy)
+    print(f"ONNX export finished in {time.perf_counter() - started:.1f}s", flush=True)

--- a/vendor/seedvr2/src/models/video_vae_v3/modules/causal_inflation_lib.py
+++ b/vendor/seedvr2/src/models/video_vae_v3/modules/causal_inflation_lib.py
@@ -91,7 +91,7 @@ class InflatedCausalConv3d(Conv3d):
         Workaround: Call torch.cudnn_convolution directly to bypass buggy layer.
         Status is logged at startup in compatibility.py.
         """
-        if (NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND and 
+        if (input.is_cuda and NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND and
             weight.dtype in (torch.float16, torch.bfloat16) and 
             hasattr(torch.backends.cudnn, 'is_available') and
             torch.backends.cudnn.is_available() and


### PR DESCRIPTION
## Summary
- Prevents the VAE cuDNN workaround from running on CPU tensors during export.
- Adds portable, observable ONNX export with cuDNN disabled, SDPA math attention, and constant folding disabled.
- Keeps CUDA export as the primary path and falls back to CPU only on CUDA OOM.
- Runs TensorRT preparation subprocesses unbuffered with per-profile progress timing.
- Documents the hang and the -SkipTensorRT workaround.

## Validation
- Affected Python files compile successfully.
- git diff --check passes.
- No Stable runtime path was changed.