### PR TITLE
Fix TensorRT ONNX export hang during install

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -41,7 +41,7 @@ TensorRT plan files are tied to the GPU architecture and runtime version. The re
 - vae_decoder_tile_512_5f.rtxplan
 - vae_decoder_tile_256_21f.rtxplan
 
-If setup stops during this stage, run it again. Existing valid plans are retained.
+If setup stops during this stage, run it again. Existing valid plans are retained. ONNX export and TensorRT builds should keep printing progress; several minutes per engine is normal.
 
 ## Logs and troubleshooting
 
@@ -51,6 +51,7 @@ Common failures:
 
 - **No NVIDIA driver detected:** install or update the NVIDIA driver, restart Windows, and rerun setup.
 - **Not enough disk space:** clear space and rerun. Partial model downloads resume.
+- **Installer sits on the legacy ONNX deprecation warning with no `Exported:` line:** this was a hang in CPU TorchScript export of the 512-tile VAE. Current builds export on the GPU with portable convolution ops. Close the stuck window, update to this version, and rerun setup. Completed engines are skipped. To finish install without TensorRT, run `.\scripts\install.ps1 -SkipTensorRT` and use SeedVR2 Legacy until you rerun a full setup.
 - **TensorRT build failure:** close GPU-heavy programs, confirm the NVIDIA driver is current, then rerun.
 - **SageAttention verification failure:** follow the [SageAttention guide](SAGEATTENTION.md).
 - **FFmpeg still missing after winget:** restart Windows so the system PATH refreshes, then rerun.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $env:PYTHONUTF8 = '1'
 $env:PYTHONIOENCODING = 'utf-8'
+$env:PYTHONUNBUFFERED = '1'
 $StudioRoot = Split-Path -Parent $PSScriptRoot
 $Outputs = Join-Path $StudioRoot 'outputs'
 $Log = Join-Path $Outputs 'install.log'

--- a/scripts/prepare_tensorrt.py
+++ b/scripts/prepare_tensorrt.py
@@ -25,19 +25,30 @@ def run(command: list[str]) -> None:
 
 def main() -> int:
     ARTIFACTS.mkdir(parents=True, exist_ok=True)
-    for label, stem, exporter, arguments in PROFILES:
+    total = len(PROFILES)
+    print(
+        f"Building {total} GPU-specific TensorRT VAE engines. "
+        "Leave this window open; each export and engine build can take several minutes.",
+        flush=True,
+    )
+    for index, (label, stem, exporter, arguments) in enumerate(PROFILES, start=1):
         onnx = ARTIFACTS / f"{stem}.onnx"
         engine = ARTIFACTS / f"{stem}.rtxplan"
         if engine.exists() and engine.stat().st_size > 1_000_000:
-            print(f"Skipping {label}; engine already exists: {engine.name}")
+            print(f"Skipping {label}; engine already exists: {engine.name}", flush=True)
             continue
-        print(f"\nPreparing TensorRT {label} profile...")
+        print(f"\nPreparing TensorRT {label} profile ({index}/{total})...", flush=True)
         if not onnx.exists():
-            run([str(PYTHON), str(ROOT / "tools" / exporter), *arguments, "--output", str(onnx)])
-        run([str(PYTHON), str(ROOT / "tools" / "build_tensorrt_engine.py"), str(onnx), "--output", str(engine), "--workspace-gb", "8"])
+            print(f"Exporting {label} ONNX graph...", flush=True)
+            run([str(PYTHON), "-u", str(ROOT / "tools" / exporter), *arguments, "--output", str(onnx)])
+        else:
+            print(f"Reusing existing ONNX: {onnx.name}", flush=True)
+        print(f"Building TensorRT engine for {label}...", flush=True)
+        run([str(PYTHON), "-u", str(ROOT / "tools" / "build_tensorrt_engine.py"), str(onnx), "--output", str(engine), "--workspace-gb", "8"])
         if not engine.exists():
             raise RuntimeError(f"TensorRT did not create {engine}")
-    print("\nAll TensorRT VAE engines are ready.")
+        print(f"Finished {label}: {engine.name}", flush=True)
+    print("\nAll TensorRT VAE engines are ready.", flush=True)
     return 0
 
 

--- a/tools/export_vae_decoder.py
+++ b/tools/export_vae_decoder.py
@@ -18,8 +18,10 @@ if hasattr(sys.stdout, "reconfigure"):
 
 ROOT = Path(__file__).resolve().parents[1]
 VENDOR = ROOT / "vendor" / "seedvr2"
+sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(VENDOR))
 
+from onnx_export_utils import export_onnx_fixed_shape  # noqa: E402
 from src.core.generation_utils import prepare_runner, setup_generation_context  # noqa: E402
 from src.core.model_loader import materialize_model  # noqa: E402
 from src.utils.debug import Debug  # noqa: E402
@@ -111,20 +113,15 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with torch.inference_mode():
         reference = decoder(latent)
-        # ONNX export must trace the portable convolution operators rather
-        # than CUDA-only aten::cudnn_convolution. Keep the CUDA result above
-        # as the reference, then export an identical CPU copy.
-        decoder_cpu = Decoder(vae.decoder.cpu()).eval()
-        latent_cpu = latent.cpu()
-        torch.onnx.export(
-            decoder_cpu,
-            (latent_cpu,),
-            str(args.output),
+        # Portable GPU export: cuDNN and fused SDPA are disabled so the
+        # tracer records Conv/MatMul instead of CUDA-only kernels.
+        export_onnx_fixed_shape(
+            decoder,
+            (latent,),
+            args.output,
             input_names=["latent"],
             output_names=["sample"],
-            opset_version=20,
             dynamo=not args.legacy_export,
-            optimize=False,
         )
     print(f"Exported: {args.output}")
     print(f"Latent shape: {tuple(latent.shape)}")

--- a/tools/export_vae_encoder.py
+++ b/tools/export_vae_encoder.py
@@ -13,8 +13,10 @@ if hasattr(sys.stdout, "reconfigure"):
 
 ROOT = Path(__file__).resolve().parents[1]
 VENDOR = ROOT / "vendor" / "seedvr2"
+sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(VENDOR))
 
+from onnx_export_utils import export_onnx_fixed_shape  # noqa: E402
 from src.core.generation_utils import prepare_runner, setup_generation_context  # noqa: E402
 from src.core.model_loader import materialize_model  # noqa: E402
 from src.models.video_vae_v3.modules.types import MemoryState  # noqa: E402
@@ -80,10 +82,16 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with torch.inference_mode():
         reference = encoder(video)
-        encoder_cpu = Encoder(vae.cpu()).eval()
-        torch.onnx.export(encoder_cpu, (video.cpu(),), str(args.output),
-                          input_names=["video"], output_names=["latent_raw"],
-                          opset_version=20, dynamo=not args.legacy_export, optimize=False)
+        # Portable GPU export: cuDNN and fused SDPA are disabled so the
+        # tracer records Conv/MatMul instead of CUDA-only kernels.
+        export_onnx_fixed_shape(
+            encoder,
+            (video,),
+            args.output,
+            input_names=["video"],
+            output_names=["latent_raw"],
+            dynamo=not args.legacy_export,
+        )
     print(f"Exported: {args.output}")
     print(f"Video shape: {tuple(video.shape)}")
     print(f"Raw latent shape: {tuple(reference.shape)}")

--- a/tools/onnx_export_utils.py
+++ b/tools/onnx_export_utils.py
@@ -1,0 +1,100 @@
+"""Portable ONNX export for TensorRT-RTX VAE graphs."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from contextlib import nullcontext
+from pathlib import Path
+
+import torch
+
+
+def _portable_attention():
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+
+        return sdpa_kernel(SDPBackend.MATH)
+    except Exception:
+        return nullcontext()
+
+
+def _to_device(
+    model: torch.nn.Module,
+    inputs: Sequence[torch.Tensor],
+    device: torch.device,
+) -> tuple[torch.nn.Module, tuple[torch.Tensor, ...]]:
+    return model.to(device), tuple(tensor.to(device) for tensor in inputs)
+
+
+def _export_on_device(
+    model: torch.nn.Module,
+    inputs: Sequence[torch.Tensor],
+    output: Path,
+    input_names: Sequence[str],
+    output_names: Sequence[str],
+    dynamo: bool,
+    opset_version: int,
+    device: torch.device,
+) -> None:
+    tracer = "dynamo" if dynamo else "legacy tracer"
+    print(
+        f"Exporting ONNX ({tracer}, portable convs) on {device} to {output.name} ...",
+        flush=True,
+    )
+    started = time.perf_counter()
+    with torch.backends.cudnn.flags(enabled=False), _portable_attention():
+        torch.onnx.export(
+            model,
+            tuple(inputs),
+            str(output),
+            input_names=list(input_names),
+            output_names=list(output_names),
+            opset_version=opset_version,
+            dynamo=dynamo,
+            optimize=False,
+            do_constant_folding=False,
+        )
+    elapsed = time.perf_counter() - started
+    print(f"ONNX export finished in {elapsed:.1f}s: {output}", flush=True)
+
+
+def export_onnx_fixed_shape(
+    model: torch.nn.Module,
+    inputs: Sequence[torch.Tensor],
+    output: Path,
+    *,
+    input_names: Sequence[str],
+    output_names: Sequence[str],
+    dynamo: bool,
+    opset_version: int = 20,
+) -> None:
+    """Trace a fixed-shape graph using portable Conv/attention ops.
+
+    GPU export is preferred. cuDNN and fused SDPA are disabled so the
+    legacy tracer records ONNX-friendly operators instead of CUDA-only
+    kernels. CUDA OOM falls back to CPU, which is slower but must not hang.
+    """
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    parameter = next(model.parameters(), None)
+    preferred = torch.device(
+        "cuda" if torch.cuda.is_available() and parameter is not None and parameter.is_cuda else "cpu"
+    )
+    try:
+        _export_on_device(
+            model, inputs, output, input_names, output_names, dynamo, opset_version, preferred
+        )
+    except torch.cuda.OutOfMemoryError:
+        if preferred.type != "cuda":
+            raise
+        print(
+            "CUDA out of memory during ONNX export; retrying on CPU. "
+            "This is slower but should complete.",
+            flush=True,
+        )
+        torch.cuda.empty_cache()
+        model, inputs = _to_device(model, inputs, torch.device("cpu"))
+        _export_on_device(
+            model, inputs, output, input_names, output_names, dynamo, opset_version, torch.device("cpu")
+        )

--- a/vendor/seedvr2/src/models/video_vae_v3/modules/causal_inflation_lib.py
+++ b/vendor/seedvr2/src/models/video_vae_v3/modules/causal_inflation_lib.py
@@ -91,8 +91,9 @@ class InflatedCausalConv3d(Conv3d):
         Workaround: Call torch.cudnn_convolution directly to bypass buggy layer.
         Status is logged at startup in compatibility.py.
         """
-        if (NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND and 
-            weight.dtype in (torch.float16, torch.bfloat16) and 
+        if (NVIDIA_CONV3D_MEMORY_BUG_WORKAROUND and
+            getattr(input, "is_cuda", False) and
+            weight.dtype in (torch.float16, torch.bfloat16) and
             hasattr(torch.backends.cudnn, 'is_available') and
             torch.backends.cudnn.is_available() and
             getattr(torch.backends.cudnn, 'enabled', True)):


### PR DESCRIPTION
The one-click installer could sit for an hour on the first TensorRT engine with no further output after the legacy TorchScript ONNX deprecation warning. Confirmed on a complete Windows install: `tensorrt_backend/artifacts` stayed empty and `outputs/install.log` never advanced past "Building GPU-specific TensorRT VAE engines."

**Cause**

`prepare_tensorrt.py` exports the 512-tile VAE encoder with `--legacy-export`, then `export_vae_encoder.py` copied the model to CPU so ONNX would contain portable `Conv` instead of `aten::cudnn_convolution`. Two things made that stall:

1. `InflatedCausalConv3d._conv_forward` called `torch.cudnn_convolution` whenever cuDNN existed, without checking `input.is_cuda`. TorchScript tracing that `try/except` on CPU tensors hangs.
2. Even without a deadlock, tracing a 3D VAE at 512x512x5 in fp16 on CPU is huge, silent, and can look frozen.

**Fix**

- Skip the cuDNN workaround unless the input is on CUDA.
- Export on GPU with cuDNN and fused SDPA disabled so the tracer still records portable Conv/MatMul.
- Disable constant folding for these giant graphs; TensorRT-RTX still optimizes at build time.
- On CUDA OOM, fall back to CPU (slow, but should finish).
- Print unbuffered per-profile progress (`python -u`, `PYTHONUNBUFFERED=1`).

Engine shapes are unchanged. Valid `.rtxplan` files are still skipped, so a rerun resumes.

**Verified** by completing install on the machine that previously hung, then launching Studio.
