### PR TITLE
Stop the Pro launcher from killing a running server

### DIFF
--- a/Install SeedVR Studio.bat
+++ b/Install SeedVR Studio.bat
@@ -9,7 +9,8 @@ echo.
 if not "%seedvr_exit_code%"=="0" (
   echo Installation failed. See the message above and outputs\install.log.
 ) else (
-  echo Installation complete. You can now launch SeedVR Studio Pro.
+  echo Installation complete.
+  echo Double-click Launch SeedVR Studio Pro.bat to start the app.
 )
 pause
 exit /b %seedvr_exit_code%

--- a/Launch SeedVR Studio Pro.bat
+++ b/Launch SeedVR Studio Pro.bat
@@ -8,9 +8,9 @@ set "seedvr_exit_code=%errorlevel%"
 if not "%seedvr_exit_code%"=="0" (
   echo.
   echo SeedVR Studio Pro failed to start. Exit code: %seedvr_exit_code%
+  echo See outputs\js_server_error.log if the window never appeared.
   pause
   exit /b %seedvr_exit_code%
 )
-echo SeedVR Studio Pro is running at http://127.0.0.1:7870
 endlocal
 exit /b 0

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,6 +51,7 @@ Common failures:
 
 - **No NVIDIA driver detected:** install or update the NVIDIA driver, restart Windows, and rerun setup.
 - **Not enough disk space:** clear space and rerun. Partial model downloads resume.
+- **Launch reports that the app window did not open:** the server often did start. Older launchers required an Edge window handle that Windows 11 does not always expose, then shut the server down. Use **Launch SeedVR Studio Pro.bat** (not the installer). If the UI still vanishes, open http://127.0.0.1:7870/ and check **outputs\js_server_error.log**.
 - **TensorRT build failure:** close GPU-heavy programs, confirm the NVIDIA driver is current, then rerun.
 - **SageAttention verification failure:** follow the [SageAttention guide](SAGEATTENTION.md).
 - **FFmpeg still missing after winget:** restart Windows so the system PATH refreshes, then rerun.

--- a/scripts/launch_js.ps1
+++ b/scripts/launch_js.ps1
@@ -73,9 +73,18 @@ function Stop-StudioProcessTree([int]$RootProcessId) {
 }
 
 function Get-StudioBrowserProcesses {
+    $profileMarker = '.studio-browser-profile'
     return Get-CimInstance Win32_Process | Where-Object {
-        $_.Name -in @('msedge.exe', 'chrome.exe') -and $_.CommandLine -like "*$BrowserProfile*"
+        $_.Name -in @('msedge.exe', 'chrome.exe') -and
+        $_.CommandLine -and
+        ($_.CommandLine -like "*$profileMarker*" -or $_.CommandLine -like "*$BrowserProfile*")
     }
+}
+
+function Test-ProcessAlive([int]$ProcessId) {
+    if (-not $ProcessId) { return $false }
+    $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    return [bool]($proc -and -not $proc.HasExited)
 }
 
 function Test-StudioAppWindow {
@@ -84,6 +93,12 @@ function Test-StudioAppWindow {
         if ($nativeProcess -and $nativeProcess.MainWindowHandle -ne 0) { return $true }
     }
     return $false
+}
+
+function Test-StudioAppRunning([int]$LaunchedProcessId) {
+    if (Test-StudioAppWindow) { return $true }
+    if (@(Get-StudioBrowserProcesses).Count -gt 0) { return $true }
+    return Test-ProcessAlive $LaunchedProcessId
 }
 
 function Stop-StudioBrowserProfile {
@@ -106,6 +121,7 @@ try {
         New-Item -ItemType Directory -Force -Path (Split-Path -Parent $LogOut) | Out-Null
         $env:PYTHONUTF8 = '1'
         $env:PYTHONIOENCODING = 'utf-8'
+        $env:PYTHONUNBUFFERED = '1'
         $server = Start-Process -FilePath $StudioPython -WorkingDirectory $StudioRoot -WindowStyle Hidden -PassThru `
             -ArgumentList '-m uvicorn api_server:app --host 127.0.0.1 --port 7870' `
             -RedirectStandardOutput $LogOut -RedirectStandardError $LogErr
@@ -135,15 +151,20 @@ try {
         '--no-first-run',
         '--disable-background-mode'
     )
-    Write-Host 'Close the SeedVR Studio window to stop rendering and release GPU/RAM.' -ForegroundColor Cyan
-    $windowSeen = $false
-    for ($attempt = 0; $attempt -lt 60; $attempt++) {
+    $appSeen = $false
+    for ($attempt = 0; $attempt -lt 80; $attempt++) {
         Start-Sleep -Milliseconds 250
-        if (Test-StudioAppWindow) { $windowSeen = $true; break }
-        if ($browser.HasExited) { break }
+        if (Test-StudioAppRunning $browser.Id) { $appSeen = $true; break }
     }
-    if (-not $windowSeen) { throw 'The SeedVR Studio app window did not open.' }
-    while (Test-StudioAppWindow) { Start-Sleep -Milliseconds 500 }
+    if ($appSeen) {
+        Write-Host 'Close the SeedVR Studio window to stop rendering and release GPU/RAM.' -ForegroundColor Cyan
+        while (Test-StudioAppRunning $browser.Id) { Start-Sleep -Milliseconds 500 }
+    }
+    else {
+        Write-Warning "The dedicated app window could not be tracked. Studio remains at $StudioUrl"
+        Write-Warning 'Use Exit Studio in the UI to release GPU and RAM.'
+        $KeepServerAfterLauncher = $true
+    }
 }
 catch {
     Write-Error $_


### PR DESCRIPTION
After a successful install, **Launch SeedVR Studio Pro.bat** started the UI and then immediately tore it down. `outputs/js_server.log` showed `/api/health`, the HTML/CSS/JS, and `/api/outputs` all 200, then `POST /api/shutdown`.

**Cause**

The launcher required `MainWindowHandle != 0` on the dedicated Edge `--app` process. Windows 11 Edge often does not expose that handle. After ~15 seconds it threw "The SeedVR Studio app window did not open" and the `finally` block shut down a healthy server.

**Fix**

- Treat a live Edge/Chrome process for the Studio browser profile (or the launched PID) as the app being open, even when there is no window handle.
- If the window still cannot be attached, leave the server running at http://127.0.0.1:7870/ instead of posting shutdown.
- Point failed starts at `outputs/js_server_error.log`, and tell the installer to use **Launch SeedVR Studio Pro.bat** to start the app.

**Verified** on the same Windows 11 machine: the Pro launcher now keeps Studio open.
