### PR TITLE
Make comparison video links play in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ VRGDG SeedVR2 TensorRT Studio turns the SeedVR2 pipeline into a practical Window
 
 Each recording demonstrates the Studio's interactive comparison view, with the original footage on one side of the wipe and the restored result on the other.
 
-- [Watch comparison sample 1 (MP4, 25 MB)](videos/comparisons/comparison-sample-01.mp4)
-- [Watch comparison sample 2 (MP4, 13 MB)](videos/comparisons/comparison-sample-02.mp4)
+- [Watch comparison sample 1 in your browser (MP4, 6.6 MB)](https://cdn.jsdelivr.net/gh/vrgamegirl19/VRGDG-SeedVR2-TensorRT-Studio@main/videos/comparisons/comparison-sample-01.mp4)
+- [Watch comparison sample 2 in your browser (MP4, 13 MB)](https://cdn.jsdelivr.net/gh/vrgamegirl19/VRGDG-SeedVR2-TensorRT-Studio@main/videos/comparisons/comparison-sample-02.mp4)
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- replace repository file-viewer links with jsDelivr streaming URLs backed by the same GitHub files
- reduce sample 1 from 25 MB to 6.6 MB so it stays within jsDelivr's per-file delivery limit
- retain the original 1418×952 resolution, 30 fps, 59-second duration, H.264 video, and AAC audio

## Validation

- both pushed video URLs return HTTP 200
- both return Content-Type: video/mp4 and Accept-Ranges: bytes for native browser playback
- sample 1 scores 0.9943 SSIM against the original encoding
- git diff --check passes

After merge, the README's @main URLs resolve to the browser-playable versions.