### PR TITLE
Fix Windows installer fallback and MP4 previews

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -197,7 +197,7 @@ def _render_job(job_id: str, source: Path, job_dir: Path, values: dict[str, obje
         if job_type == "preview":
             start = min(max(float(values["preview_start"]), 0.0), max(info.duration - 0.1, 0.0))
             length = min(float(values["preview_seconds"]), max(info.duration - start, 0.1))
-            source_for_render = make_clip(source, job_dir / "source.mp4", start, length)
+            source_for_render = make_clip(source, job_dir / "preview-source.mp4", start, length)
             output = job_dir / "restored.mp4"
         else:
             source_for_render = source

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,13 +34,37 @@ function Refresh-Path {
 function Find-Python312 {
     $py = Get-Command py.exe -ErrorAction SilentlyContinue
     if ($py) {
-        $path = & $py.Source -3.12 -c "import sys; print(sys.executable)" 2>$null
-        if ($LASTEXITCODE -eq 0 -and $path) { return ($path | Select-Object -Last 1).Trim() }
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'SilentlyContinue'
+            $path = & $py.Source -3.12 -c "import sys; print(sys.executable)" 2>$null
+            $pyExitCode = $LASTEXITCODE
+        }
+        catch {
+            $path = $null
+            $pyExitCode = 1
+        }
+        finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        if ($pyExitCode -eq 0 -and $path) { return ($path | Select-Object -Last 1).Trim() }
     }
     $python = Get-Command python.exe -ErrorAction SilentlyContinue
     if ($python) {
-        $version = & $python.Source -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
-        if ($LASTEXITCODE -eq 0 -and [version]$version -eq [version]'3.12') { return $python.Source }
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'SilentlyContinue'
+            $version = & $python.Source -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+            $pythonExitCode = $LASTEXITCODE
+        }
+        catch {
+            $version = $null
+            $pythonExitCode = 1
+        }
+        finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        if ($pythonExitCode -eq 0 -and $version -and [version]$version -eq [version]'3.12') { return $python.Source }
     }
     $locations = @(
         (Join-Path $env:LocalAppData 'Programs\Python\Python312\python.exe'),


### PR DESCRIPTION
## Summary

- prevent expected Python launcher stderr from aborting install.ps1 before the Winget fallback
- preserve strict installer error handling after Python detection probes
- write shortened MP4 previews to preview-source.mp4 instead of overwriting the uploaded source.mp4

## Validation

- git diff --check
- Windows PowerShell 5.1 syntax parser
- Windows PowerShell 5.1 native stderr/nonzero-exit regression check
- Python syntax compilation
- real FFmpeg MP4 preview clipping test with distinct input and output paths