### PR TITLE
Fix JavaScript MIME type on Windows

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -461,4 +461,16 @@ def media(relative_path: str) -> FileResponse:
     return FileResponse(candidate)
 
 
+@app.get("/app.js", include_in_schema=False)
+def serve_app_js() -> FileResponse:
+    # Windows can register .js as text/plain. Module scripts require a
+    # JavaScript MIME type, so do not leave this asset to MIME guessing.
+    return FileResponse(WEB / "app.js", media_type="application/javascript")
+
+
+@app.get("/styles.css", include_in_schema=False)
+def serve_styles_css() -> FileResponse:
+    return FileResponse(WEB / "styles.css", media_type="text/css")
+
+
 app.mount("/", StaticFiles(directory=WEB, html=True), name="web")


### PR DESCRIPTION
## Summary

- serve pp.js explicitly as pplication/javascript
- serve styles.css explicitly as 	ext/css
- register both routes before the catch-all static mount

This avoids Windows MIME registry mappings that can cause Starlette to return JavaScript as 	ext/plain, which Chromium refuses to execute as a module.

## Verification

- python -m py_compile api_server.py
- FastAPI TestClient: /app.js returns 200 application/javascript
- FastAPI TestClient: /styles.css returns 200 text/css; charset=utf-8
- git diff --check

Closes #22