### PR TITLE
Control restored video output size

### DIFF
--- a/tools/assemble_tensor_video.py
+++ b/tools/assemble_tensor_video.py
@@ -142,16 +142,36 @@ def main() -> None:
         frames, args.audio, args.target_width, args.target_height
     )
     temp = args.output.with_name(args.output.stem + "_noaudio.mp4")
-    writer = cv2.VideoWriter(str(temp), cv2.VideoWriter_fourcc(*"avc1"), args.fps,
-                             output_size)
-    if not writer.isOpened():
-        writer = cv2.VideoWriter(str(temp), cv2.VideoWriter_fourcc(*"mp4v"), args.fps,
-                                 output_size)
-    for frame in frames:
-        if (frame.shape[1], frame.shape[0]) != output_size:
-            frame = cv2.resize(frame, output_size, interpolation=cv2.INTER_LINEAR)
-        writer.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
-    writer.release()
+    width, height = output_size
+    # OpenCV chooses a backend-specific bitrate. A fixed CRF keeps restored
+    # detail high while preventing unexpectedly oversized output files.
+    encode_command = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-f", "rawvideo", "-pix_fmt", "rgb24",
+        "-s:v", f"{width}x{height}", "-r", f"{args.fps:.9g}", "-i", "pipe:0",
+        "-an", "-c:v", "libx264", "-preset", "medium", "-crf", "18",
+        "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(temp),
+    ]
+    encoder = subprocess.Popen(encode_command, stdin=subprocess.PIPE)
+    write_error = None
+    try:
+        assert encoder.stdin is not None
+        for frame in frames:
+            if (frame.shape[1], frame.shape[0]) != output_size:
+                frame = cv2.resize(frame, output_size, interpolation=cv2.INTER_LINEAR)
+            encoder.stdin.write(frame.tobytes())
+    except BrokenPipeError as exc:
+        write_error = exc
+    finally:
+        if encoder.stdin is not None:
+            encoder.stdin.close()
+    return_code = encoder.wait()
+    if return_code:
+        temp.unlink(missing_ok=True)
+        raise subprocess.CalledProcessError(return_code, encode_command) from write_error
+    if write_error is not None:
+        temp.unlink(missing_ok=True)
+        raise write_error
     if args.audio:
         video_duration = frames.shape[0] / max(args.fps, 1e-6)
         subprocess.run(["ffmpeg", "-y", "-i", str(temp), "-i", str(args.audio),


### PR DESCRIPTION
## Summary

- replace OpenCV's backend-dependent final video encoding with FFmpeg libx264
- use high-quality constant-quality encoding at CRF 18 with the medium preset
- stream RGB frames into FFmpeg to avoid a second full-video byte copy
- retain the existing optional AAC audio muxing behavior
- remove partial temporary output when encoding fails

OpenCV's VideoWriter did not specify a bitrate or quality target, so output size varied by local codec backend and could become unexpectedly large.

## Verification

- python -m py_compile tools/assemble_tensor_video.py
- assembled a synthetic decoded tensor into H.264 High / yuv420p
- verified 60 frames, 30 fps, and 2-second duration with fprobe
- repeated assembly with a source audio track and verified H.264 video plus AAC audio
- git diff --check

Closes #24