### PR TITLE
Fix Windows command-line limit when assembling long TensorRT renders

### DIFF
--- a/seedvr_studio/backend.py
+++ b/seedvr_studio/backend.py
@@ -308,9 +308,12 @@ def reprocess_tensorrt(
             progress_callback(0.75 * index / len(decoded_files), f"Post-processing batch {index} of {len(decoded_files)}")
     if progress_callback:
         progress_callback(0.8, "Applying seam treatment and assembling video")
-    command = [str(VENV_PYTHON), str(TRT_ASSEMBLER), *map(str, selected_files),
-               "--output", str(output), "--audio", str(source), "--fps", str(resolve_frame_rate(probe(source).fps)),
-               "--seam-mode", seam_mode, "--seam-frames", str(seam_frames)]
+    from .tensorrt_pipeline import assemble_command
+    command = assemble_command(
+        selected_files, output, source,
+        fps=resolve_frame_rate(probe(source).fps),
+        seam_mode=seam_mode, seam_frames=seam_frames,
+    )
     result = subprocess.run(command, cwd=ROOT, env=child_env, text=True,
                             encoding="utf-8", errors="replace", capture_output=True)
     _safe_print(result.stdout, end="")

--- a/seedvr_studio/tensorrt_pipeline.py
+++ b/seedvr_studio/tensorrt_pipeline.py
@@ -49,6 +49,36 @@ def _safe_print(value: str, *, end: str = "\n") -> None:
         print(value.encode(encoding, errors="replace").decode(encoding, errors="replace"), end=end, flush=True)
 
 
+def assemble_command(
+    selected_files: list[Path],
+    output: Path,
+    source: Path,
+    *,
+    fps: float,
+    seam_mode: str,
+    seam_frames: int,
+    target_width: int = 0,
+    target_height: int = 0,
+) -> list[str]:
+    """Build an assembler command that does not exceed the Windows argument limit."""
+    list_path = output.parent / "assemble-inputs.txt"
+    list_path.write_text("\n".join(str(path) for path in selected_files) + "\n", encoding="utf-8")
+    command = [
+        str(VENV_PYTHON), str(TRT_ASSEMBLER),
+        "--input-list", str(list_path),
+        "--output", str(output),
+        "--audio", str(source),
+        "--fps", f"{fps:.9g}",
+        "--seam-mode", seam_mode,
+        "--seam-frames", str(seam_frames),
+    ]
+    if target_width > 0:
+        command.extend(["--target-width", str(target_width)])
+    if target_height > 0:
+        command.extend(["--target-height", str(target_height)])
+    return command
+
+
 def _profile_latents(latent_files: list[Path]) -> list[dict[str, Any]]:
     profiles: list[dict[str, Any]] = []
     for index, latent_file in enumerate(latent_files, start=1):
@@ -218,11 +248,13 @@ def decode_postprocess_and_assemble(
     target_width, target_height = _unpadded_output_size(
         source, settings.resolution, settings.max_resolution
     )
-    assemble = [
-        str(VENV_PYTHON), str(TRT_ASSEMBLER), *map(str, selected_files), "--output", str(output),
-        "--audio", str(source), "--fps", f"{source_fps:.9g}", "--seam-mode", settings.seam_mode, "--seam-frames", str(settings.seam_frames),
-        "--target-width", str(target_width), "--target-height", str(target_height),
-    ]
+    assemble = assemble_command(
+        selected_files, output, source,
+        fps=source_fps, seam_mode=settings.seam_mode, seam_frames=settings.seam_frames,
+        target_width=target_width, target_height=target_height,
+    )
+    if progress_callback:
+        progress_callback(0.96, f"Assembling {len(selected_files)} decoded batches")
     result = subprocess.run(
         assemble, cwd=ROOT, env=child_env, text=True, encoding="utf-8", errors="replace", capture_output=True
     )

--- a/tools/assemble_tensor_video.py
+++ b/tools/assemble_tensor_video.py
@@ -64,7 +64,9 @@ def smooth_boundary(previous: torch.Tensor, current: torch.Tensor, mode: str, fr
     return result.to(dtype=current.dtype)
 
 
-def crop_decoder_padding(frames, reference: Path | None, target_width: int = 0, target_height: int = 0):
+def crop_decoder_padding(
+    frames, reference: Path | None, target_width: int = 0, target_height: int = 0, *, log: bool = True
+):
     """Remove TensorRT's bottom/right alignment padding using the source aspect ratio.
 
     TensorRT alignment rows are not guaranteed to remain exactly black after
@@ -79,7 +81,7 @@ def crop_decoder_padding(frames, reference: Path | None, target_width: int = 0, 
                 f"Requested unpadded size {target_width}x{target_height} exceeds "
                 f"decoded canvas {frame_width}x{frame_height}"
             )
-        if (target_width, target_height) != (frame_width, frame_height):
+        if log and (target_width, target_height) != (frame_width, frame_height):
             print(
                 f"Removing known resize padding: {frame_width}x{frame_height} "
                 f"-> {target_width}x{target_height}"
@@ -98,7 +100,7 @@ def crop_decoder_padding(frames, reference: Path | None, target_width: int = 0, 
         target_width = frame_width
         target_height = max(2, round(target_width / source_ratio) // 2 * 2)
         if target_height <= frame_height:
-            if target_height != frame_height:
+            if log and target_height != frame_height:
                 print(f"Removing TensorRT alignment padding: {frame_width}x{frame_height} -> {target_width}x{target_height}")
             frames = frames[:, :target_height, :target_width, :]
             return frames, (target_width, target_height)
@@ -106,18 +108,36 @@ def crop_decoder_padding(frames, reference: Path | None, target_width: int = 0, 
         target_height = frame_height
         target_width = max(2, round(target_height * source_ratio) // 2 * 2)
         if target_width <= frame_width:
-            if target_width != frame_width:
+            if log and target_width != frame_width:
                 print(f"Removing TensorRT alignment padding: {frame_width}x{frame_height} -> {target_width}x{target_height}")
             frames = frames[:, :target_height, :target_width, :]
             return frames, (target_width, target_height)
-    if (target_width, target_height) != (frame_width, frame_height):
+    if log and (target_width, target_height) != (frame_width, frame_height):
         print(f"Restoring source aspect: {frame_width}x{frame_height} -> {target_width}x{target_height}")
     return frames, (target_width, target_height)
 
 
+def _input_paths(args: argparse.Namespace) -> list[Path]:
+    paths = list(args.inputs)
+    if args.input_list:
+        for line in args.input_list.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if text and not text.startswith("#"):
+                paths.append(Path(text))
+    if not paths:
+        raise ValueError("Provide decoded tensors as arguments or --input-list")
+    return paths
+
+
+def _uint8_frames(tensor: torch.Tensor):
+    frames = tensor[0].permute(1, 2, 3, 0)
+    return ((frames.float().clamp(-1, 1) + 1) * 127.5).byte().numpy()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("inputs", type=Path, nargs="+")
+    parser.add_argument("inputs", type=Path, nargs="*")
+    parser.add_argument("--input-list", type=Path, help="Text file with one decoded tensor path per line")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--audio", type=Path)
     parser.add_argument("--fps", type=float, default=24.0)
@@ -126,45 +146,55 @@ def main() -> None:
     parser.add_argument("--target-width", type=int, default=0)
     parser.add_argument("--target-height", type=int, default=0)
     args = parser.parse_args()
-    tensors = []
-    for path in args.inputs:
-        tensor, keep = load_video_tensor(path)
-        if keep is not None:
-            tensor = tensor[:, :, :keep]
-        if tensors:
-            tensor = smooth_boundary(tensors[-1], tensor, args.seam_mode, args.seam_frames)
-        tensors.append(tensor)
-    if not tensors:
-        raise ValueError("At least one decoded tensor is required")
-    frames = torch.cat(tensors, dim=2)[0].permute(1, 2, 3, 0)
-    frames = ((frames.float().clamp(-1, 1) + 1) * 127.5).byte().numpy()
-    frames, output_size = crop_decoder_padding(
-        frames, args.audio, args.target_width, args.target_height
-    )
+    inputs = _input_paths(args)
     temp = args.output.with_name(args.output.stem + "_noaudio.mp4")
-    width, height = output_size
-    # OpenCV chooses a backend-specific bitrate. A fixed CRF keeps restored
-    # detail high while preventing unexpectedly oversized output files.
-    encode_command = [
-        "ffmpeg", "-y", "-loglevel", "error",
-        "-f", "rawvideo", "-pix_fmt", "rgb24",
-        "-s:v", f"{width}x{height}", "-r", f"{args.fps:.9g}", "-i", "pipe:0",
-        "-an", "-c:v", "libx264", "-preset", "medium", "-crf", "18",
-        "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(temp),
-    ]
-    encoder = subprocess.Popen(encode_command, stdin=subprocess.PIPE)
+    encoder = None
+    encode_command: list[str] = []
+    output_size = None
+    previous = None
+    total_frames = 0
     write_error = None
     try:
-        assert encoder.stdin is not None
-        for frame in frames:
-            if (frame.shape[1], frame.shape[0]) != output_size:
-                frame = cv2.resize(frame, output_size, interpolation=cv2.INTER_LINEAR)
-            encoder.stdin.write(frame.tobytes())
+        for index, path in enumerate(inputs, start=1):
+            tensor, keep = load_video_tensor(path)
+            if keep is not None:
+                tensor = tensor[:, :, :keep]
+            if previous is not None:
+                tensor = smooth_boundary(previous, tensor, args.seam_mode, args.seam_frames)
+            frames = _uint8_frames(tensor)
+            frames, batch_size = crop_decoder_padding(
+                frames, args.audio, args.target_width, args.target_height, log=index == 1
+            )
+            if encoder is None:
+                output_size = batch_size
+                width, height = output_size
+                encode_command = [
+                    "ffmpeg", "-y", "-loglevel", "error",
+                    "-f", "rawvideo", "-pix_fmt", "rgb24",
+                    "-s:v", f"{width}x{height}", "-r", f"{args.fps:.9g}", "-i", "pipe:0",
+                    "-an", "-c:v", "libx264", "-preset", "medium", "-crf", "18",
+                    "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(temp),
+                ]
+                encoder = subprocess.Popen(encode_command, stdin=subprocess.PIPE)
+                print(f"Assembling {len(inputs)} decoded batches...", flush=True)
+            assert encoder.stdin is not None
+            for frame in frames:
+                if (frame.shape[1], frame.shape[0]) != output_size:
+                    frame = cv2.resize(frame, output_size, interpolation=cv2.INTER_LINEAR)
+                encoder.stdin.write(frame.tobytes())
+            total_frames += int(frames.shape[0])
+            previous = tensor
+            if index == 1 or index == len(inputs) or index % 50 == 0:
+                print(f"Assembled batch {index} of {len(inputs)} ({total_frames} frames)", flush=True)
+        if encoder is None:
+            raise ValueError("At least one decoded tensor is required")
     except BrokenPipeError as exc:
         write_error = exc
     finally:
-        if encoder.stdin is not None:
+        if encoder is not None and encoder.stdin is not None:
             encoder.stdin.close()
+    if encoder is None:
+        raise ValueError("At least one decoded tensor is required")
     return_code = encoder.wait()
     if return_code:
         temp.unlink(missing_ok=True)
@@ -173,14 +203,14 @@ def main() -> None:
         temp.unlink(missing_ok=True)
         raise write_error
     if args.audio:
-        video_duration = frames.shape[0] / max(args.fps, 1e-6)
+        video_duration = total_frames / max(args.fps, 1e-6)
         subprocess.run(["ffmpeg", "-y", "-i", str(temp), "-i", str(args.audio),
                         "-map", "0:v:0", "-map", "1:a:0?", "-c:v", "copy",
                         "-c:a", "aac", "-t", f"{video_duration:.9f}", str(args.output)], check=True)
         temp.unlink(missing_ok=True)
     else:
         temp.replace(args.output)
-    print(f"Frames: {frames.shape[0]}")
+    print(f"Frames: {total_frames}")
     print(f"Output: {output_size[0]}x{output_size[1]} @ {args.fps:g}fps")
     print(f"Saved: {args.output}")
 


### PR DESCRIPTION
A 3:20 music video finished DiT + TensorRT decode (960 batches / 4800 frames) then died at assembly:

```
FileNotFoundError: [WinError 206] The filename or extension is too long
```

in `decode_postprocess_and_assemble` at `subprocess.run` of `assemble_tensor_video.py`.

**Cause**

Every decoded `.pt` path was passed as a CLI argument. ~960 paths at ~90 characters each is well over the Windows `CreateProcess` 32,767-character limit.

Loading all 960 tensors and concatenating them would also have been likely to OOM on the next step (~60 GB of fp16 + a 30 GB uint8 frame buffer).

**Fix**

- Write `assemble-inputs.txt` and pass `--input-list` (also used by post-only reprocess).
- Stream one batch at a time into ffmpeg instead of concatenating the whole job in RAM.

**Recovery**

The original job's decoded batches were assembled with this path. Output:

`outputs/js-full-443b07dc00/source-restored.mp4` (1904x1080, 3:20, with source audio).
