### PR TITLE
Fix CUDA OOM during TensorRT ONNX export

### DIFF
--- a/tools/onnx_export_utils.py
+++ b/tools/onnx_export_utils.py
@@ -7,6 +7,30 @@ from contextlib import nullcontext
 from pathlib import Path
 
 import torch
+from torch.onnx import symbolic_helper
+
+
+@symbolic_helper.parse_args("v", "v", "is", "is", "is", "i", "b", "b", "b")
+def _cudnn_convolution_symbolic(
+    graph, value, weight, padding, stride, dilation, groups,
+    benchmark, deterministic, allow_tf32,
+):
+    """Export the low-memory direct-cuDNN path as a portable ONNX Conv."""
+    del benchmark, deterministic, allow_tf32
+    return graph.op(
+        "Conv",
+        value,
+        weight,
+        dilations_i=dilation,
+        group_i=groups,
+        pads_i=[*padding, *padding],
+        strides_i=stride,
+    )
+
+
+torch.onnx.register_custom_op_symbolic(
+    "aten::cudnn_convolution", _cudnn_convolution_symbolic, 20
+)
 
 
 def _math_attention_context():
@@ -19,7 +43,10 @@ def _math_attention_context():
 
 def _portable_export(module: torch.nn.Module, args: tuple[torch.Tensor, ...], output: Path, *, legacy: bool) -> None:
     is_encoder = args[0].ndim == 5 and args[0].shape[1] == 3
-    with torch.inference_mode(), torch.backends.cudnn.flags(enabled=False), _math_attention_context():
+    # Keep cuDNN enabled so SeedVR2's direct-cuDNN Conv3d workaround remains
+    # active. The custom symbolic above converts that CUDA-only operator into
+    # a standard, portable ONNX Conv for TensorRT.
+    with torch.inference_mode(), torch.backends.cudnn.flags(enabled=True), _math_attention_context():
         torch.onnx.export(
             module,
             args,


### PR DESCRIPTION
## Problem

The fixed-shape TensorRT ONNX exporter disables cuDNN while tracing. On recent pinned PyTorch/cuDNN builds, this bypasses SeedVR2's direct-cuDNN Conv3d memory workaround and routes the VAE through a convolution implementation that attempts a roughly 38 GB CUDA allocation. The 21-frame encoder therefore falls back to an extremely slow CPU export on 16 GB and 24 GB GPUs. The 5-frame decoder can fail similarly.

## Root cause

`InflatedCausalConv3d` intentionally calls `aten::cudnn_convolution` to avoid the affected PyTorch Conv3d dispatch path. `onnx_export_utils._portable_export` disabled cuDNN because the legacy ONNX exporter has no built-in symbolic for that operator. Disabling cuDNN made the graph portable, but removed the low-memory execution path during tracing.

## Fix

Keep cuDNN enabled during legacy ONNX tracing and register an opset-20 symbolic that maps `aten::cudnn_convolution` to a standard ONNX `Conv`. Padding, stride, dilation, and group attributes are preserved. The resulting graph contains only standard ONNX operators and remains consumable by TensorRT RTX.

## Validation

Tested end-to-end on an NVIDIA RTX 4070 Ti SUPER with 16 GB VRAM, PyTorch `2.15.0.dev20260824+cu130`, cuDNN 92400, and TensorRT RTX 1.6.1.120.

- Exported the 21-frame 512x512 encoder in 2.1 seconds without OOM or CPU fallback.
- Validated the generated model with `onnx.checker.check_model`.
- Confirmed the graph contained 27 standard-domain `Conv` nodes and no custom operator domains.
- Built the 21-frame encoder TensorRT plan successfully.
- Ran the normal `scripts/prepare_tensorrt.py` flow successfully for the remaining profiles.
- Deserialized and executed the 5-frame encoder, 21-frame encoder, 5-frame decoder, and 21-frame decoder plans. All produced finite outputs with their expected fixed shapes.
- Ran `scripts/verify_install.py` successfully.
- Ran Python bytecode compilation and `git diff --check` successfully.

This avoids both the impossible CUDA allocation and the multi-hour CPU fallback while retaining a portable ONNX graph.
