### PR TITLE
Avoid GPU OOM during large TensorRT setup exports

### DIFF
--- a/scripts/prepare_tensorrt.py
+++ b/scripts/prepare_tensorrt.py
@@ -24,6 +24,16 @@ def run(command: list[str]) -> None:
     subprocess.run([command[0], "-u", *command[1:]], cwd=ROOT, check=True)
 
 
+def export_with_fallback(exporter: str, arguments: tuple[str, ...], onnx: Path) -> None:
+    """Export on GPU first, retrying on CPU if the GPU export fails."""
+    gpu_arguments = (*arguments, "--device", "cuda")
+    try:
+        run([str(PYTHON), str(ROOT / "tools" / exporter), *gpu_arguments, "--output", str(onnx)])
+    except subprocess.CalledProcessError:
+        print("GPU ONNX export failed; retrying this profile on CPU to avoid setup OOM.", flush=True)
+        cpu_arguments = (*arguments, "--device", "cpu")
+        run([str(PYTHON), str(ROOT / "tools" / exporter), *cpu_arguments, "--output", str(onnx)])
+
 def main() -> int:
     ARTIFACTS.mkdir(parents=True, exist_ok=True)
     for label, stem, exporter, arguments in PROFILES:
@@ -33,11 +43,9 @@ def main() -> int:
             print(f"Skipping {label}; engine already exists: {engine.name}")
             continue
         print(f"\nPreparing TensorRT {label} profile (keep this window open)...", flush=True)
-        if "--device" in arguments and "cpu" in arguments:
-            print("Using CPU export for this large profile to avoid GPU out-of-memory during setup.", flush=True)
         started = time.perf_counter()
         if not onnx.exists():
-            run([str(PYTHON), str(ROOT / "tools" / exporter), *arguments, "--output", str(onnx)])
+            export_with_fallback(exporter, arguments, onnx)
         run([str(PYTHON), str(ROOT / "tools" / "build_tensorrt_engine.py"), str(onnx), "--output", str(engine), "--workspace-gb", "8"])
         if not engine.exists():
             raise RuntimeError(f"TensorRT did not create {engine}")

--- a/scripts/prepare_tensorrt.py
+++ b/scripts/prepare_tensorrt.py
@@ -33,6 +33,8 @@ def main() -> int:
             print(f"Skipping {label}; engine already exists: {engine.name}")
             continue
         print(f"\nPreparing TensorRT {label} profile (keep this window open)...", flush=True)
+        if "--device" in arguments and "cpu" in arguments:
+            print("Using CPU export for this large profile to avoid GPU out-of-memory during setup.", flush=True)
         started = time.perf_counter()
         if not onnx.exists():
             run([str(PYTHON), str(ROOT / "tools" / exporter), *arguments, "--output", str(onnx)])

--- a/tools/export_vae_decoder.py
+++ b/tools/export_vae_decoder.py
@@ -68,6 +68,7 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=1)
     parser.add_argument("--legacy-export", action="store_true",
                         help="Use the legacy fixed-shape ONNX tracer")
+    parser.add_argument("--device", choices=("cuda", "cpu"), default="cuda", help="Device used for ONNX export; CPU avoids large GPU allocations.")
     parser.add_argument("--output", type=Path, default=ROOT / "tensorrt_backend" / "artifacts" / "vae_decoder.onnx")
     args = parser.parse_args()
 
@@ -86,7 +87,7 @@ def main() -> None:
     )
     # TensorRT parity target is FP16; keep this experiment independent of the
     # normal pipeline's automatic bfloat16 choice.
-    ctx["compute_dtype"] = torch.float16
+    ctx["compute_dtype"] = torch.float16 if device.type == "cuda" else torch.float32
     runner, _ = prepare_runner(
         dit_model=DEFAULT_DIT,
         vae_model=DEFAULT_VAE,
@@ -107,7 +108,7 @@ def main() -> None:
 
     latent = torch.randn(
         args.batch_size, 16, args.latent_frames, args.height // 8, args.width // 8,
-        device=device, dtype=torch.float16,
+        device=device, dtype=torch.float16 if device.type == "cuda" else torch.float32,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with torch.inference_mode():

--- a/tools/export_vae_encoder.py
+++ b/tools/export_vae_encoder.py
@@ -57,6 +57,7 @@ def main() -> None:
     parser.add_argument("--frames", type=int, default=5)
     parser.add_argument("--output", type=Path, default=ROOT / "tensorrt_backend" / "artifacts" / "vae_encoder.onnx")
     parser.add_argument("--legacy-export", action="store_true")
+    parser.add_argument("--device", choices=("cuda", "cpu"), default="cuda", help="Device used for ONNX export; CPU avoids large GPU allocations.")
     args = parser.parse_args()
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required for the VAE export")
@@ -66,7 +67,7 @@ def main() -> None:
     debug = Debug(enabled=True)
     ctx = setup_generation_context(dit_device=device, vae_device=device,
                                    tensor_offload_device=None, debug=debug)
-    ctx["compute_dtype"] = torch.float16
+    ctx["compute_dtype"] = torch.float16 if device.type == "cuda" else torch.float32
     runner, _ = prepare_runner(
         dit_model=DEFAULT_DIT, vae_model=DEFAULT_VAE,
         model_dir=str(ROOT / "models" / "SEEDVR2"), debug=debug, ctx=ctx,


### PR DESCRIPTION
Closes #26

TensorRT VAE ONNX export now keeps the normal GPU-first path. If a GPU export fails (including out-of-memory during a large profile), setup retries that profile on CPU instead of stopping with an apparent hang. The encoder and decoder exporters accept an explicit `--device cuda|cpu` option, and the setup output clearly reports the CPU retry.

Users with sufficient VRAM keep the existing GPU export behavior; the CPU path is only a fallback for the affected profile.

Verification:
- `prepare_tensorrt.py`, `export_vae_encoder.py`, and `export_vae_decoder.py` pass Python syntax checks locally.
- Full model export was not run because the workspace does not contain the installed model/runtime environment.